### PR TITLE
Stop to call recycle

### DIFF
--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
@@ -86,7 +86,6 @@ internal class Apng(
 
     fun recycle() {
         ApngDecoderJni.recycle(id)
-        bitmap.recycle()
     }
 
     fun copy(): Apng = copy(this)


### PR DESCRIPTION
In some device, calling `recycle` causes TimeoutException and heap corruption.