### PR TITLE
Fix frame duration calculation

### DIFF
--- a/apng-drawable/src/main/cpp/apng-drawbale/ApngDecoderJni.cpp
+++ b/apng-drawable/src/main/cpp/apng-drawbale/ApngDecoderJni.cpp
@@ -95,7 +95,8 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_decode(
 ) {
   LOGV("decode start");
 #ifdef BUILD_DEBUG
-  std::chrono::system_clock::time_point start, end;
+  std::chrono::system_clock::time_point start;
+  std::chrono::system_clock::time_point end;
   start = std::chrono::system_clock::now();
 #endif
   int32_t resultCode;

--- a/apng-drawable/src/main/cpp/apng-drawbale/ApngDecoderJni.cpp
+++ b/apng-drawable/src/main/cpp/apng-drawbale/ApngDecoderJni.cpp
@@ -38,8 +38,12 @@ static jfieldID gResult_heightFieldID;
 static jfieldID gResult_widthFieldID;
 static jfieldID gResult_frameCountFieldID;
 static jfieldID gResult_repeatCountFieldID;
-static jfieldID gResult_durationFieldID;
+static jfieldID gResult_frameDurationsFieldID;
 static jfieldID gResult_allFrameByteCountFieldID;
+
+bool copyFrameDurations(JNIEnv *env,
+                        const std::shared_ptr<ApngImage> &image,
+                        jintArray &frame_durations_ptr);
 
 extern "C" {
 #pragma clang diagnostic push
@@ -59,7 +63,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
   gResult_widthFieldID = env->GetFieldID(gResult_class, "width", "I");
   gResult_frameCountFieldID = env->GetFieldID(gResult_class, "frameCount", "I");
   gResult_repeatCountFieldID = env->GetFieldID(gResult_class, "loopCount", "I");
-  gResult_durationFieldID = env->GetFieldID(gResult_class, "duration", "I");
+  gResult_frameDurationsFieldID = env->GetFieldID(gResult_class, "frameDurations", "[I");
   gResult_allFrameByteCountFieldID = env->GetFieldID(gResult_class, "allFrameByteCount", "J");
   StreamSource::registerJavaClass(env);
   return JNI_VERSION_1_6;
@@ -74,7 +78,7 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved) {
   gResult_widthFieldID = nullptr;
   gResult_frameCountFieldID = nullptr;
   gResult_repeatCountFieldID = nullptr;
-  gResult_durationFieldID = nullptr;
+  gResult_frameDurationsFieldID = nullptr;
   gResult_allFrameByteCountFieldID = nullptr;
   env->DeleteGlobalRef(gResult_class);
   gResult_class = nullptr;
@@ -103,7 +107,7 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_decode(
 
   // decode
   std::unique_ptr<StreamSource> source(new StreamSource(env, inputStream));
-  std::unique_ptr<ApngImage> image = ApngDecoder::decode(std::move(source), resultCode);
+  std::shared_ptr<ApngImage> image = std::move(ApngDecoder::decode(std::move(source), resultCode));
 
   LOGV(" | decode result: %d", resultCode);
 
@@ -125,9 +129,16 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_decode(
   env->SetIntField(result, gResult_heightFieldID, image->getHeight());
   env->SetIntField(result, gResult_frameCountFieldID, image->getFrameCount());
   env->SetIntField(result, gResult_repeatCountFieldID, image->getRepeatCount());
-  env->SetIntField(result, gResult_durationFieldID, image->getTotalDuration());
   env->SetLongField(result, gResult_allFrameByteCountFieldID, image->getAllFrameByteCount());
-
+  {
+    jintArray frame_durations = env->NewIntArray(image->getFrameCount());
+    if (!frame_durations) {
+      return ERR_OUT_OF_MEMORY;
+    }
+    copyFrameDurations(env, image, frame_durations);
+    env->SetObjectField(result, gResult_frameDurationsFieldID, frame_durations);
+    env->DeleteLocalRef(frame_durations);
+  }
   {
     std::lock_guard<std::mutex> lock(gLock);
     gIdCounter++;
@@ -151,7 +162,7 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_isApng(
   return static_cast<jboolean>(result);
 }
 
-JNIEXPORT jint JNICALL
+JNIEXPORT void JNICALL
 Java_com_linecorp_apng_decoder_ApngDecoderJni_draw(
     JNIEnv *env,
     jclass thiz,
@@ -162,22 +173,22 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_draw(
   void *data;
 
   if (id < 0) {
-    return ERR_NOT_EXIST_IMAGE;
+    return;
   }
   if (index < 0) {
-    return ERR_FRAME_INDEX_OUT_OF_RANGE;
+    return;
   }
 
   int32_t result;
   if ((result = AndroidBitmap_lockPixels(env, bitmap, &data)) < 0) {
     LOGE("Error in AndroidBitmap_lockPixels. errorCode: %d", result);
-    return ERR_BITMAP_OPERATION;
+    return;
   }
 
   AndroidBitmapInfo info;
   if ((result = AndroidBitmap_getInfo(env, bitmap, &info)) < 0) {
     LOGE("Error in AndroidBitmap_getInfo. errorCode: %d", result);
-    return ERR_BITMAP_OPERATION;
+    return;
   }
 
   std::shared_ptr<ApngImage> image = nullptr;
@@ -191,28 +202,16 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_draw(
 
   if (!image) {
     AndroidBitmap_unlockPixels(env, bitmap);
-    return ERR_NOT_EXIST_IMAGE;
+    return;
   }
 
   std::shared_ptr<ApngFrame> frame = image->getFrame(static_cast<const uint32_t>(index));
   if (!frame) {
     AndroidBitmap_unlockPixels(env, bitmap);
-    return ERR_FRAME_INDEX_OUT_OF_RANGE;
+    return;
   }
   memcpy(data, frame->getRawPixels(), image->getFrameByteCount());
-  size_t duration = frame->getDuration();
-
   AndroidBitmap_unlockPixels(env, bitmap);
-
-  if (result < 0) {
-    return result;
-  }
-
-  if (duration > 0) {
-    return static_cast<jint>(duration);
-  }
-
-  return SUCCESS;
 }
 
 JNIEXPORT jint JNICALL
@@ -259,8 +258,18 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_copy(
   env->SetIntField(result, gResult_heightFieldID, copyPtr->getHeight());
   env->SetIntField(result, gResult_frameCountFieldID, copyPtr->getFrameCount());
   env->SetIntField(result, gResult_repeatCountFieldID, copyPtr->getRepeatCount());
-  env->SetIntField(result, gResult_durationFieldID, copyPtr->getTotalDuration());
   env->SetLongField(result, gResult_allFrameByteCountFieldID, copyPtr->getAllFrameByteCount());
+
+  {
+    uint32_t frame_count = copyPtr->getFrameCount();
+    jintArray frame_durations = env->NewIntArray(frame_count);
+    if (!frame_durations) {
+      return ERR_OUT_OF_MEMORY;
+    }
+    copyFrameDurations(env, copyPtr, frame_durations);
+    env->SetObjectField(result, gResult_frameDurationsFieldID, frame_durations);
+    env->DeleteLocalRef(frame_durations);
+  }
 
   int32_t resultId = ++gIdCounter;
   gImageMap.emplace(resultId, std::move(copyPtr));
@@ -271,4 +280,23 @@ Java_com_linecorp_apng_decoder_ApngDecoderJni_copy(
 
 #pragma clang diagnostic pop
 }
+
+bool copyFrameDurations(JNIEnv *env,
+                        const std::shared_ptr<ApngImage> &image,
+                        jintArray &frame_durations_ptr) {
+  uint32_t frame_count = image->getFrameCount();
+  jint *frame_durations_array = env->GetIntArrayElements(frame_durations_ptr, nullptr);
+  bool isSuccess = true;
+  for (uint32_t i = 0; i < frame_count; ++i) {
+    std::shared_ptr<ApngFrame> frame = image->getFrame(i);
+    if (!frame) {
+      isSuccess = false;
+      break;
+    }
+    frame_durations_array[i] = frame->getDuration();
+  }
+  env->ReleaseIntArrayElements(frame_durations_ptr, frame_durations_array, 0);
+  return isSuccess;
+}
+
 }

--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
@@ -46,11 +46,8 @@ internal class Apng(
      */
     @IntRange(from = 1, to = Int.MAX_VALUE.toLong())
     val frameCount: Int,
-    /**
-     * The duration to animate one loop of APNG animation.
-     */
-    @IntRange(from = 0, to = Int.MAX_VALUE.toLong())
-    val duration: Int,
+
+    val frameDurations: IntArray,
     /**
      * The number of times to loop this APNG image. The value must be a signed value.
      * `0` indicates infinite looping.
@@ -78,6 +75,12 @@ internal class Apng(
         Trace.endSection()
     }
 
+    /**
+     * The duration to animate one loop of APNG animation.
+     */
+    @IntRange(from = 0, to = Int.MAX_VALUE.toLong())
+    val duration: Int = frameDurations.sum()
+
     val isRecycled: Boolean
         get() = bitmap.isRecycled
 
@@ -100,16 +103,12 @@ internal class Apng(
 
     /**
      * Draws specified frame to the [canvas].
-     *
-     * @return the duration of this frame if the drawing process is finished correctly,
-     * or error code if any error has happened while the drawing process.
      */
-    fun drawWithIndex(frameIndex: Int, canvas: Canvas, src: Rect?, dst: Rect, paint: Paint): Int {
+    fun drawWithIndex(frameIndex: Int, canvas: Canvas, src: Rect?, dst: Rect, paint: Paint) {
         Trace.beginSection("Apng#draw")
-        val result = ApngDecoderJni.draw(id, frameIndex, bitmap)
+        ApngDecoderJni.draw(id, frameIndex, bitmap)
         Trace.endSection()
         canvas.drawBitmap(bitmap, src, dst, paint)
-        return result
     }
 
     /**
@@ -126,7 +125,7 @@ internal class Apng(
         var height: Int = 0
         var frameCount: Int = 0
         var loopCount: Int = 0
-        var duration: Int = 0
+        var frameDurations: IntArray = intArrayOf()
         var allFrameByteCount: Long = 0
     }
 
@@ -150,7 +149,7 @@ internal class Apng(
                     result.width,
                     result.height,
                     result.frameCount,
-                    result.duration,
+                    result.frameDurations,
                     result.loopCount,
                     result.allFrameByteCount
                 )
@@ -186,7 +185,7 @@ internal class Apng(
                     result.width,
                     result.height,
                     result.frameCount,
-                    result.duration,
+                    result.frameDurations,
                     result.loopCount,
                     result.allFrameByteCount
                 )

--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/ApngDecoderJni.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/ApngDecoderJni.kt
@@ -35,7 +35,7 @@ internal object ApngDecoderJni {
     external fun recycle(id: Int): Int
 
     @JvmStatic
-    external fun draw(id: Int, index: Int, bitmap: Bitmap): Int
+    external fun draw(id: Int, index: Int, bitmap: Bitmap)
 
     @JvmStatic
     external fun copy(id: Int, result: Apng.DecodeResult): Int

--- a/apng-drawable/src/test/kotlin/com/linecorp/apng/ApngDrawableTest.kt
+++ b/apng-drawable/src/test/kotlin/com/linecorp/apng/ApngDrawableTest.kt
@@ -50,8 +50,11 @@ class ApngDrawableTest {
         MockitoAnnotations.initMocks(this)
         whenever(nBitmapAnimation.width).thenReturn(200)
         whenever(nBitmapAnimation.height).thenReturn(100)
-        whenever(nBitmapAnimation.duration).thenReturn(100)
         whenever(nBitmapAnimation.frameCount).thenReturn(10)
+        whenever(nBitmapAnimation.frameDurations).thenReturn(
+            intArrayOf(10, 10, 5, 20, 5, 10, 10, 10, 10, 10)
+        )
+        whenever(nBitmapAnimation.duration).thenReturn(100)
         whenever(nBitmapAnimation.loopCount).thenReturn(2)
         currentTimeProvider = CurrentTimeProvider(0L)
         target = ApngDrawable(
@@ -108,6 +111,26 @@ class ApngDrawableTest {
         target.draw(canvas)
         verify(nBitmapAnimation, times(1)).drawWithIndex(
             eq(1),
+            eq(canvas),
+            anyOrNull(),
+            eq(Rect(0, 0, 200, 100)),
+            any()
+        )
+
+        currentTimeProvider.currentTimeMillis = 24L
+        target.draw(canvas)
+        verify(nBitmapAnimation, times(1)).drawWithIndex(
+            eq(2),
+            eq(canvas),
+            anyOrNull(),
+            eq(Rect(0, 0, 200, 100)),
+            any()
+        )
+
+        currentTimeProvider.currentTimeMillis = 25L
+        target.draw(canvas)
+        verify(nBitmapAnimation, times(1)).drawWithIndex(
+            eq(3),
             eq(canvas),
             anyOrNull(),
             eq(Rect(0, 0, 200, 100)),


### PR DESCRIPTION
Currently, rendering frame index is calculated from total duration of image. However, APNG can have duration for each frames (fcTL section).

>The `delay_num` and `delay_den` parameters together specify a fraction indicating the time to display the current frame, in seconds. If the denominator is 0, it is to be treated as if it were 100 (that is, `delay_num` then specifies 1/100ths of a second). If the the value of the numerator is 0 the decoder should render the next frame as quickly as possible, though viewers may impose a reasonable lower bound.
>Frame timings should be independent of the time required for decoding and display of each frame, so that animations will run at the same rate regardless of the performance of the decoder implementation.

https://wiki.mozilla.org/APNG_Specification#.60fcTL.60:_The_Frame_Control_Chunk