### PR TITLE
Add license information for Maven POM

### DIFF
--- a/apng-drawable/build.gradle.kts
+++ b/apng-drawable/build.gradle.kts
@@ -137,6 +137,22 @@ tasks.getByName("install", Upload::class).apply {
                     groupId = ModuleConfig.groupId
                     artifactId = ModuleConfig.artifactId
                     version = ModuleConfig.version
+                    withGroovyBuilder {
+                        "licenses" {
+                            // License for apng-drawable itself
+                            "license" {
+                                setProperty("name", "Apache-2.0")
+                                setProperty("url", "https://www.apache.org/licenses/LICENSE-2.0.txt")
+                                setProperty("distribution", "repo")
+                            }
+                            // License for libpng/apng-patch
+                            "license" {
+                                setProperty("name", "Zlib")
+                                setProperty("url", "http://www.zlib.net/zlib_license.html")
+                                setProperty("distribution", "repo")
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
I tried to use [Google Play OSS plugin](https://developers.google.com/android/guides/opensource) to show license notice on app.
But apng-drawable does not have license on POM, so it cannot show apng-drawable license.

https://docs.gradle.org/current/userguide/maven_plugin.html#sec:maven_convention_methods
https://maven.apache.org/pom.html#Licenses