### PR TITLE
Modify the class modifier to make it more friendly to other image lib…

### DIFF
--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/Apng.kt
@@ -30,7 +30,7 @@ import java.io.InputStream
  * A class which holds APNG image information and bridge to the native(jni) layer.
  * When finished to use this class, you must explicitly call [recycle].
  */
-internal class Apng(
+class Apng(
     private val id: Int,
     /**
      * The width of the image

--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/ApngDecoderJni.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/decoder/ApngDecoderJni.kt
@@ -19,7 +19,7 @@ package com.linecorp.apng.decoder
 import android.graphics.Bitmap
 import java.io.InputStream
 
-internal object ApngDecoderJni {
+object ApngDecoderJni {
 
     init {
         System.loadLibrary("apng-drawable")


### PR DESCRIPTION
I'm writing a wrapper for glide and I don't want to use the original source for a project. 
for android, the following two APIs are required.
```kotlin
Apng.Companion.isApng(source)
ApngDrawable.decode(xxx)
```
