### PR TITLE
Fix a potential crash caused by ConcurrentModificationException

### DIFF
--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/ApngDrawable.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/ApngDrawable.kt
@@ -324,7 +324,9 @@ class ApngDrawable @VisibleForTesting internal constructor(
                 isFirstLoop() &&
                 animationPrevDrawTimeMillisSnapShot == null
             ) {
-                animationCallbacks.forEach {
+                // Make a copy of the list for safe iteration
+                val callbacksCopy = animationCallbacks.toList()
+                callbacksCopy.forEach {
                     it.onAnimationStart(this)
                 }
             } else if (
@@ -332,7 +334,9 @@ class ApngDrawable @VisibleForTesting internal constructor(
                 hasNextLoop() &&
                 frameChanged
             ) {
-                repeatAnimationCallbacks.forEach {
+                // Make a copy of the list for safe iteration
+                val callbacksCopy = repeatAnimationCallbacks.toList()
+                callbacksCopy.forEach {
                     // TODO: Remove `onRepeat` invocation at the next version.
                     @Suppress("DEPRECATION")
                     it.onRepeat(this, currentLoopIndexInternal + 2)
@@ -342,7 +346,9 @@ class ApngDrawable @VisibleForTesting internal constructor(
         }
         if (exceedsRepeatCountLimitation()) {
             isStarted = false
-            animationCallbacks.forEach {
+            // Make a copy of the list for safe iteration
+            val callbacksCopy = animationCallbacks.toList()
+            callbacksCopy.forEach {
                 it.onAnimationEnd(this)
             }
         }

--- a/apng-drawable/src/test/kotlin/com/linecorp/apng/ApngDrawableTest.kt
+++ b/apng-drawable/src/test/kotlin/com/linecorp/apng/ApngDrawableTest.kt
@@ -18,6 +18,8 @@ package com.linecorp.apng
 
 import android.graphics.Canvas
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import com.linecorp.apng.decoder.Apng
 import com.linecorp.apng.utils.assertFailureMessage
 import com.nhaarman.mockitokotlin2.any
@@ -205,6 +207,29 @@ class ApngDrawableTest {
             eq(Rect(0, 0, 200, 100)),
             any()
         )
+    }
+
+    @Test
+    fun testDraw_withRegisterAnimationCallbackMultipleTimes() {
+        currentTimeProvider.currentTimeMillis = 0L
+
+        repeat (3) {
+            target.registerAnimationCallback(object : Animatable2Compat.AnimationCallback() {
+                override fun onAnimationEnd(drawable: Drawable?) {
+                    target.unregisterAnimationCallback(this)
+                }
+            })
+        }
+
+        target.start()
+
+        currentTimeProvider.currentTimeMillis = 10L
+
+        target.draw(canvas)
+
+        currentTimeProvider.currentTimeMillis = 1_000L
+
+        target.draw(canvas)
     }
 
     @Test


### PR DESCRIPTION
### Crash logs

```
java.util.ConcurrentModificationException
  at java.util.ArrayList$Itr.checkForComodification
  at java.util.ArrayList$Itr.next
  at com.linecorp.apng.ApngDrawable.progressAnimationElapsedTime
  at com.linecorp.apng.ApngDrawable.draw
  at android.widget.ImageView.onDraw
```

### Steps to reproduce

If the client registers an animation callback multiple times—potentially due to timing issues or intentional actions by client apps—and then unregisters themselves during the callback execution (a reasonable approach), it triggers a `ConcurrentModificationException`.

#### Sample code

```kotlin
// repeat this action multiple times.
apngDrawable.registerAnimationCallback(object : Animatable2Compat.AnimationCallback() {
    override fun onAnimationEnd(drawable: Drawable?) {
        apngDrawable.unregisterAnimationCallback(this)
    }
})
```

