### PR TITLE
Fix crash when all durations are zero

### DIFF
--- a/apng-drawable/src/main/kotlin/com/linecorp/apng/ApngDrawable.kt
+++ b/apng-drawable/src/main/kotlin/com/linecorp/apng/ApngDrawable.kt
@@ -132,13 +132,13 @@ class ApngDrawable @VisibleForTesting internal constructor(
      */
     val currentFrameIndex: Int
         get() {
-            var progressMillisInCurrentLoop = animationElapsedTimeMillis % durationMillis
+            var progressMillisInCurrentLoop = if (durationMillis == 0) 0 else animationElapsedTimeMillis % durationMillis
             progressMillisInCurrentLoop += if (exceedsRepeatCountLimitation()) durationMillis else 0
             return calculateCurrentFrameIndex(0, frameCount - 1, progressMillisInCurrentLoop)
         }
 
     private val currentLoopIndexInternal: Int
-        get() = (animationElapsedTimeMillis / durationMillis).toInt()
+        get() = if (durationMillis == 0) 0 else (animationElapsedTimeMillis / durationMillis).toInt()
     private val paint: Paint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.DITHER_FLAG)
     private val animationCallbacks: MutableList<Animatable2Compat.AnimationCallback> = arrayListOf()
     private val repeatAnimationCallbacks: MutableList<RepeatAnimationCallback> = arrayListOf()


### PR DESCRIPTION
Hi,

I am developing an Android application for multiple SNS like bluesky, mastodon and misskey.

We have been using this library as an APNG decoder for a social networking service called Misskey, but there was a problem with crashes when loading an incorrect file with a total duration of 0.

This fix prevents crashes as a minimum fix.

It is desirable to be able to set some kind of duration and display all frames as animated, but I could not figure out how to do that, so the first frame is displayed as a fixed frame.

Thanks.

sample:
![midopen_duration_zero](https://github.com/line/apng-drawable/assets/73930/5bde09ad-c65b-44dc-99cd-421a9a487f1a)
