### PR TITLE
 Fixes to support 16KB page size

### DIFF
--- a/apng-drawable/build.gradle.kts
+++ b/apng-drawable/build.gradle.kts
@@ -28,6 +28,7 @@ android {
                 cppFlags += "-std=c++17"
                 cppFlags += "-fno-rtti"
                 cppFlags += "-fexceptions"
+                arguments += listOf("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
             }
         }
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,7 @@ object Versions {
     const val minSdkVersion = 19
     const val compileSdkVersion = 30
     const val targetSdkVersion = 30
-    const val ndkVersion = "21.4.7075529"
+    const val ndkVersion = "27.0.11718014"
 
     // Library
     const val androidxAppCompatVersion = "1.0.1"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     // Plugin
     const val androidPluginVersion = "7.0.1"
     const val ktlintGradleVersion = "10.0.0"
-    const val dokkaVersion = "1.4.20"
+    const val dokkaVersion = "1.5.30"
     const val gradleVersionsPluginVersion = "0.36.0"
     const val nexusStagingVersion = "0.22.0"
 

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -33,6 +33,11 @@ android {
     buildFeatures {
         viewBinding = true
     }
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
16KB page size mode has been added from Android15.
- https://developer.android.com/about/versions/15/behavior-changes-all?hl=ja#16-kb

To accommodate this, I made changes to the version etc. with reference to the following.
- https://developer.android.com/guide/practices/page-sizes#kotlin