### PR TITLE
perf: avoid too large buffer allocations

### DIFF
--- a/apng-drawable/src/main/cpp/apng-drawable/ApngDecoder.cpp
+++ b/apng-drawable/src/main/cpp/apng-drawable/ApngDecoder.cpp
@@ -206,9 +206,8 @@ std::unique_ptr<ApngImage> ApngDecoder::decode(
     result = ERR_INVALID_FILE_FORMAT;
     return nullptr;
   }
-  size_t row_ptr_array_size = height * sizeof(png_bytep);
-  std::unique_ptr<png_bytep[]> rows_frame(new png_bytep[row_ptr_array_size]);
-  std::unique_ptr<png_bytep[]> rows_buffer(new png_bytep[row_ptr_array_size]);
+  std::unique_ptr<png_bytep[]> rows_frame(new png_bytep[height]);
+  std::unique_ptr<png_bytep[]> rows_buffer(new png_bytep[height]);
   if (!p_frame || !p_buffer || !p_previous_frame || !rows_frame || !rows_buffer) {
     LOGV(" | failed to allocate buffers");
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
@@ -284,7 +283,8 @@ std::unique_ptr<ApngImage> ApngDecoder::decode(
                             &blend_op);
     auto duration =
         static_cast<size_t>(std::lround(static_cast<float>(delay_num) / delay_den * 1000.F));
-    std::unique_ptr<ApngFrame> frame(new ApngFrame(size, duration));
+    size_t frameBytesAsUint32 = height * width; // The frame expects the pixels to be a uint32_t array, so we don't need to multiply by 4
+    std::unique_ptr<ApngFrame> frame(new ApngFrame(frameBytesAsUint32, duration));
     if (i == first) {
       blend_op = PNG_BLEND_OP_SOURCE;
       if (dispose_op == PNG_DISPOSE_OP_PREVIOUS) {


### PR DESCRIPTION
I noticed that displaying an png was taking a significant amount of memory.

After some profiling I found too issues that cause too much memory allocations:

1. The `rows_frame` and `rows_buffer` are `png_bytep` arrays. C++ will already allocate the elements to have a size of `png_bytep`. Us multiplying the height with the `sizeof(png_bytep)` is actually not needed.
	- (However, I think `sizeof(png_bytep)` returns `1` anyway. However, for correctness I added this change.
2. The main improvement is to only pass `height * width` as frame byte size to the `ApngFrame`:
	- Before it was `size = height * row_bytes` where `row_bytes` is basically `width * channels (4)`
	- But the `ApngFrame`s internal pixel array is already a `uint32_t`. Meaning one value already includes the precomputed value for all channels (see `saveFrame`).
	- **Thus the `ApngFrame`s internal pixel array is oversized by 4x**. By changing it to `width * height` its size is correct

We had an extreme case where the animation (and rest of the app) before took ~1.7GB:

![CleanShot 2025-02-20 at 10 34 29](https://github.com/user-attachments/assets/1c486935-4bc7-44da-848c-9456cee165d1)



With this change we were able to bring it down to ~700mb, a 2.3x improvement:

![CleanShot 2025-02-20 at 10 36 15](https://github.com/user-attachments/assets/9d83a152-fbea-46b5-977f-01329f3a4b49)

Related to: 

- https://github.com/line/apng-drawable/issues/108
- https://github.com/line/apng-drawable/issues/74

> [!IMPORTANT]
> This performance improvement was sponsored by [Discord](https://discord.com) 🌟
