### PR TITLE
chore(example): add remove button to test memory correctness

### DIFF
--- a/sample-app/src/main/kotlin/com/linecorp/apngsample/MainActivity.kt
+++ b/sample-app/src/main/kotlin/com/linecorp/apngsample/MainActivity.kt
@@ -88,6 +88,7 @@ class MainActivity : AppCompatActivity() {
         binding.buttonSeekStart.setOnClickListener { seekTo(0L) }
         binding.buttonSeekEnd.setOnClickListener { seekTo(10000000L) }
         binding.buttonSaveCurrentFrame.setOnClickListener { exportCurrentFrame() }
+        binding.buttonRemove.setOnClickListener { removeView() }
     }
 
     @SuppressLint("SetTextI18n")
@@ -194,6 +195,14 @@ class MainActivity : AppCompatActivity() {
             bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
         }
         return@withContext uri
+    }
+
+    // Tests whether removing the view will release the memory
+    private fun removeView() {
+        binding.imageView.setImageDrawable(null)
+        drawable?.clearAnimationCallbacks()
+        drawable?.recycle()
+        drawable = null
     }
 
     private abstract class AnimationCallbacks

--- a/sample-app/src/main/res/layout/activity_main.xml
+++ b/sample-app/src/main/res/layout/activity_main.xml
@@ -58,6 +58,12 @@
                 android:layout_height="wrap_content"
                 android:text="@string/copy" />
 
+            <Button
+                android:id="@+id/button_remove"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/remove" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/sample-app/src/main/res/values/strings.xml
+++ b/sample-app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="load_10x">Load (10x)</string>
     <string name="mutate">Mutate</string>
     <string name="copy">Copy</string>
+    <string name="remove">Remove</string>
     <string name="commands">Commands</string>
     <string name="use_inputstream">Use InputStream</string>
     <string name="normal_png">Normal PNG</string>


### PR DESCRIPTION
I added a test button to fully remove the view and recycle the drawable.
This is useful for testing if the memory gets correctly released.


https://github.com/user-attachments/assets/b56362d5-8dce-47e8-a3ab-7c21ed07ddc0

> [!IMPORTANT]
> This work was sponsored by [Discord](https://discord.com) 🌟
